### PR TITLE
fix the go mod cannot get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module wifi-password-qr
+module github.com/hSATAC/wifi-password-qr
 
 require (
 	github.com/keybase/go-keychain v0.0.0-20181011010623-f1daa725cce4


### PR DESCRIPTION
fix the go module name in go mod file to fulfill new golang module prefixing

this should fix:
https://github.com/hSATAC/wifi-password-qr/issues/5